### PR TITLE
Re-organizing so ProfileSetupFragment on MainActivity instead

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,14 +25,15 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Wings">
 
-        <activity android:name=".startactivity.StartActivity" />
-        <activity android:name=".mainactivity.MainActivity">
+        <activity android:name=".startactivity.StartActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name=".mainactivity.MainActivity"> </activity>
 
         <meta-data
             android:name="preloaded_fonts"

--- a/app/src/main/java/com/example/wings/mainactivity/MAFragmentsListener.java
+++ b/app/src/main/java/com/example/wings/mainactivity/MAFragmentsListener.java
@@ -8,7 +8,9 @@ package com.example.wings.mainactivity;
 //NOTE:     Because there is only one listener used by all fragments and the MainActivity, this means any Fragment can invoke any other Fragment easily, which is something we may want to change later. This
 //          can be done with in-class listeners later so that only specific Fragments can invoke specific methods  i.e HomeFragment.HomeFragmentListener{}
 public interface MAFragmentsListener {
+    public void setRestrictScreen(boolean answer);
     public void toHomeFragment();
+    public void toProfileSetupFragment();
     public void toUserProfileFragment();
     public void toSearchUserFragment();
     public void toOtherProfileFragment();

--- a/app/src/main/java/com/example/wings/startactivity/StartActivity.java
+++ b/app/src/main/java/com/example/wings/startactivity/StartActivity.java
@@ -51,9 +51,13 @@ public class StartActivity extends AppCompatActivity implements SAFragmentsListe
     @Override
     //Purpose:      based on the given key --> goes to either ProfileSetUpFrag or HomeFrag
     public void onLogin(String key) {
+        Log.d(TAG, "in onLogin(): key="+key);
         Intent intent = new Intent(this, MainActivity.class);
         if(key.equals(KEY_PROFILESETUPFRAG)){
             intent.putExtra(KEY_PROFILESETUPFRAG, true);        //tell MainActivity to start on ProfileSetupFrag
+        }
+        else{
+            intent.putExtra(KEY_PROFILESETUPFRAG, false);
         }
         startActivity(intent);
         finish();

--- a/app/src/main/java/com/example/wings/startactivity/fragments/LoginFragment.java
+++ b/app/src/main/java/com/example/wings/startactivity/fragments/LoginFragment.java
@@ -92,21 +92,23 @@ public class LoginFragment extends Fragment {
                 ParseUser.logInInBackground(usernameTxt, passwordTxt, new LogInCallback() {
 
                     @Override
-                    public void done(ParseUser pUser, ParseException e) {
+                    public void done(ParseUser user, ParseException e) {
                         //if there is a user --> tell StartActivity of successful login
-                        if(pUser != null){
-                            User user = (User) pUser;
-
-                            //Send user to HomeFrag or ProfileSetupFrag depending if they setup their profile yet:
-                            if(user.getProfileSetUp()){
-                                listener.onLogin("go to HomeFrag");
-                            }
-                            listener.onLogin(KEY_SEND_PROFILESETUPFRAG);
-
+                        if(user != null){
                             //Notify user of successful login:
                             Toast toast = Toast.makeText(getContext(), "You're logged in!", Toast.LENGTH_SHORT);
                             toast.setGravity(Gravity.TOP, 0,0);
                             toast.show();
+
+                            //Send user to HomeFrag or ProfileSetupFrag depending if they setup their profile yet:
+                            Log.d(DEBUG_TAG, "profileSetUp = " + user.getBoolean(User.KEY_PROFILESETUP));
+                            if(user.getBoolean(User.KEY_PROFILESETUP)){
+                                listener.onLogin("go to HomeFrag");     //just something not the ProfileSetupFrag key
+                            }
+                            else {
+                                listener.onLogin(KEY_SEND_PROFILESETUPFRAG);
+                            }
+
                         } else {
                             Toast.makeText(getContext(), "This user doesn't exist. Please Sign-up!", Toast.LENGTH_SHORT).show();
                             Log.d(DEBUG_TAG, "logInInBackground(): failed" + e.getMessage());


### PR DESCRIPTION
New organization:
- app launches with startActivity --> LoginFrag
- StartActivity.onLogin(String key):
   - intent to MainActivity
   - key = tells whether MainActivity needs to begin on ProfileSetupFrag or default to HomeFrag
   - intent puts Boolean extra to let MainActivity know
- MainActivity.onCreate():
   - gets the Boolean extra, if it is = true --> must start on ProfileSetupFrag and restrict user to only that page
      - the bottom nav is then not functional
      -  user can only go to SettingsFrag, HelpFrag, or Logout
  - else the Boolean extra = false --> starts on HomeFrag like normal
- ProfileSetupFrag():
   - obtains the current user logged in and updates the neccesary fields: profilePic, TrustedContacts, PIN
   -  once all are valid --> changes User's field "profileSetUp = true", so that the next time this user logs in, they go straight to HomeFrag
-  LoginFrag --> changed to check if the logged in user's "profileSetUp = true or false", then calls StartActivity.onLogin(key = either profileSetup or homeFrag)


TODO:
- [ ]  include a back button on RegisterTwoFrag and save all User info
- [ ] include back button for MainActivity when on the restricted screen with ProfileSetUpFrag:
   - e.g. can go to Settings but there's no way to go back to ProfileSetUp again